### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ifetch-tools (0.18.2-2) UNRELEASED; urgency=low
+
+  * Use secure URI in Homepage field.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Wed, 02 Sep 2020 06:02:09 -0000
+
 ifetch-tools (0.18.2-1) unstable; urgency=medium
 
   [ Richard Nelson ]

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,8 @@
 ifetch-tools (0.18.2-2) UNRELEASED; urgency=low
 
   * Use secure URI in Homepage field.
+  * Fix day-of-week for changelog entries 0.15.24-1, 0.15.16-1, 0.15.15-1,
+    0.15.12a-1.
 
  -- Debian Janitor <janitor@jelmer.uk>  Wed, 02 Sep 2020 06:02:09 -0000
 
@@ -394,7 +396,7 @@ ifetch-tools (0.15.24-1) experimental; urgency=low
   * Added feature to export images to a video download.
   * Added depends of ffmepg for video download feature.
 
- -- Richard Nelson <unixabg@gmail.com>  Wed, 5 Jul 2012 17:42:00 -0600
+ -- Richard Nelson <unixabg@gmail.com>  Thu, 05 Jul 2012 17:42:00 -0600
 
 ifetch-tools (0.15.23b-1) unstable; urgency=low
 
@@ -523,14 +525,14 @@ ifetch-tools (0.15.16-1) unstable; urgency=low
   * Bumped version of wwwifetch to 0.8.8
   * Added ability for custom htdocs folder.
 
- -- Richard Nelson <unixabg@gmail.com>  Thu, 25 May 2010 22:06:00 -0600
+ -- Richard Nelson <unixabg@gmail.com>  Tue, 25 May 2010 22:06:00 -0600
 
 ifetch-tools (0.15.15-1) unstable; urgency=low
 
   * Bumped version of ifetch to 0.14.8
   * Attempt to avoid nil split errors in Drb exchanges.
 
- -- Richard Nelson <unixabg@gmail.com>  Thu, 05 Feb 2010 22:00:00 -0600
+ -- Richard Nelson <unixabg@gmail.com>  Fri, 05 Feb 2010 22:00:00 -0600
 
 ifetch-tools (0.15.14-1) unstable; urgency=low
 
@@ -553,7 +555,7 @@ ifetch-tools (0.15.12a-1) unstable; urgency=low
   -- Corrected spelling on variable name.
   -- Bumped versions in man pages and web page.
 
- -- Richard Nelson <unixabg@gmail.com>  Fri, 07 Dec 2009 15:30:00 -0600
+ -- Richard Nelson <unixabg@gmail.com>  Mon, 07 Dec 2009 15:30:00 -0600
 
 ifetch-tools (0.15.11-1) unstable; urgency=low
 

--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: Richard Nelson <unixabg@gmail.com>
 Build-Depends:
  debhelper-compat (= 12),
 Standards-Version: 4.4.1
-Homepage: http://fyeox.com/ifetch-tools/
+Homepage: https://fyeox.com/ifetch-tools/
 Vcs-Browser: https://github.com/unixabg/ifetch-tools
 Vcs-Git: https://github.com/unixabg/ifetch-tools.git
 Rules-Requires-Root: no


### PR DESCRIPTION
Fix some issues reported by lintian
* Use secure URI in Homepage field. ([homepage-field-uses-insecure-uri](https://lintian.debian.org/tags/homepage-field-uses-insecure-uri.html))
* Fix day-of-week for changelog entries 0.15.24-1, 0.15.16-1, 0.15.15-1, 0.15.12a-1. ([debian-changelog-has-wrong-day-of-week](https://lintian.debian.org/tags/debian-changelog-has-wrong-day-of-week.html))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/ifetch-tools/915c4c50-ab9c-4c20-9d0b-69f8438d3b7d.


## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)
### Control files: lines which differ (wdiff format)
* Homepage: [-http&#8203;://fyeox.com/ifetch-tools/-] {+https&#8203;://fyeox.com/ifetch-tools/+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/915c4c50-ab9c-4c20-9d0b-69f8438d3b7d/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/915c4c50-ab9c-4c20-9d0b-69f8438d3b7d/diffoscope)).
