### PR TITLE
Install and use sysusers.d/tmpfiles.d config files

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,6 +3,7 @@ Section: web
 Maintainer: Richard Nelson <unixabg@gmail.com>
 Build-Depends:
  debhelper-compat (= 13),
+ dh-sequence-installsysusers,
 Standards-Version: 4.7.3
 Homepage: https://fyeox.com/ifetch-tools/
 Vcs-Browser: https://github.com/unixabg/ifetch-tools
@@ -14,7 +15,6 @@ Architecture: all
 Pre-Depends:
  ${misc:Pre-Depends},
 Depends:
- adduser,
  ffmpeg,
  init-system-helpers,
  ruby,

--- a/debian/ifetch-tools.postinst
+++ b/debian/ifetch-tools.postinst
@@ -7,44 +7,6 @@ set -e
 # Set the prompt to remove data, logs, and settings each removal.
 db_fset ifetch-tools/remove seen false
 
-case "${1}" in
-	configure)
-		if ! getent passwd "ifetch-tools" > /dev/null 2>&1
-		then
-			# Add new user account
-			adduser --system --shell /bin/false --disabled-password --home /var/lib/ifetch-tools --gecos 'ifetch-tools account' --group --quiet ifetch-tools
-			if ! getent group "ifetch-tools" > /dev/null 2>&1
-			then
-				# Add existing user to new new group
-				addgroup --system --quiet ifetch-tools
-				gpasswd -a ifetch-tools ifetch-tools
-			fi
-		fi
-
-		mkdir -p /etc/ifetch-tools/cameras
-		mkdir -p /var/log/ifetch-tools
-
-		chown ifetch-tools:ifetch-tools /var/log/ifetch-tools /etc/ifetch-tools /etc/ifetch-tools/cameras
-		chmod 700 /etc/ifetch-tools /etc/ifetch-tools/cameras /var/lib/ifetch-tools
-
-		if [ ! -e /etc/ifetch-tools/ifetch-tools.conf ]
-		then
-			cp /usr/share/ifetch-tools/examples/ifetch-tools.conf /etc/ifetch-tools/ifetch-tools.conf
-			chmod 600 /etc/ifetch-tools/ifetch-tools.conf
-			chown ifetch-tools:ifetch-tools /etc/ifetch-tools/ifetch-tools.conf
-		fi
-		;;
-
-	abort-upgrade|abort-remove|abort-deconfigure)
-
-		;;
-
-	*)
-		echo "postinst called with unknown argument \`${1}'" >&2
-		exit 1
-		;;
-esac
-
 #DEBHELPER#
 
 exit 0

--- a/debian/ifetch-tools.postrm
+++ b/debian/ifetch-tools.postrm
@@ -20,8 +20,6 @@ case "${1}" in
 			rm -rf /etc/ifetch-tools
 			rm -rf /var/lib/ifetch-tools
 			rm -rf /var/log/ifetch-tools
-			userdel ifetch-tools >/dev/null 2>&1 || true
-			groupdel ifetch-tools >/dev/null 2>&1 || true
 		fi
 		;;
 
@@ -34,8 +32,6 @@ case "${1}" in
 		if [ -d /var/lib/ifetch-tools ]
 		then
 			rm -rf /var/lib/ifetch-tools
-			userdel ifetch-tools >/dev/null 2>&1 || true
-			groupdel ifetch-tools >/dev/null 2>&1 || true
 		fi
 
 		if [ -d /var/log/ifetch-tools ]

--- a/debian/ifetch-tools.sysusers
+++ b/debian/ifetch-tools.sysusers
@@ -1,0 +1,1 @@
+u! ifetch-tools - "ifetch-tools account" /var/lib/ifetch-tools /bin/false

--- a/debian/ifetch-tools.tmpfiles
+++ b/debian/ifetch-tools.tmpfiles
@@ -1,0 +1,5 @@
+d /var/lib/ifetch-tools 0700 ifetch-tools ifetch-tools
+d /var/log/ifetch-tools 0755 ifetch-tools ifetch-tools
+d /etc/ifetch-tools 0700 ifetch-tools ifetch-tools
+d /etc/ifetch-tools/cameras 0700 ifetch-tools ifetch-tools
+C /etc/ifetch-tools/ifetch-tools.conf 0600 ifetch-tools ifetch-tools - /usr/share/ifetch-tools/examples/ifetch-tools.conf


### PR DESCRIPTION
sysusers.d/tmpfiles.d config files allow a package to use declarative
configuration instead of manually written maintainer scripts. This also
allows image-based systems to be created with /usr/ only, and also
allows for factory resetting a system and recreating /etc/ on boot.

https://www.freedesktop.org/software/systemd/man/latest/sysusers.d.html
https://www.freedesktop.org/software/systemd/man/latest/tmpfiles.d.html

Note that this does not require a hard dependency on systemd,
debhelper generates depetencies correctly so that they work out
of the box on non-systemd and non-linux Debian builds seamlessly.